### PR TITLE
Fix isReady$ event by hooking to cv.onRuntimeInitialized

### DIFF
--- a/projects/ng-open-cv/src/lib/ng-open-cv.service.ts
+++ b/projects/ng-open-cv/src/lib/ng-open-cv.service.ts
@@ -67,14 +67,17 @@ export class NgOpenCVService {
     script.setAttribute('async', '');
     script.setAttribute('type', 'text/javascript');
     script.addEventListener('load', () => {
-      if (options.onRuntimeInitialized) {
-        options.onRuntimeInitialized();
-      }
-      this.isReady.next({
-        ready: true,
-        error: false,
-        loading: false
-      });
+      const onRuntimeInitializedCallback = () => {
+        if (options.onRuntimeInitialized) {
+          options.onRuntimeInitialized();
+        }
+        this.isReady.next({
+          ready: true,
+          error: false,
+          loading: false
+        });
+      };
+      cv.onRuntimeInitialized = onRuntimeInitializedCallback;
     });
     script.addEventListener('error', () => {
       const err = this.printError('Failed to load ' + this.OPENCV_URL);


### PR DESCRIPTION
This commit fixes situation when OpenCV was used just after Angular app init. Even though isReady$
observable was used to check if library is loaded, some features like `cv.Mat` constructor were not available.

Previously calling `cv.matFromArray` (of course wrapped in ngOpenCVService.isReady$ subscribe callback) in some component's ngOnInit resulted in error:
```
TypeError: cv.mat is not a constructor
```
