### PR TITLE
ci: fix npm publish trigger

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -2,6 +2,7 @@ name: Publish npm package
 
 on:
   pull_request:
+  workflow_dispatch:
   # A merge of the release PR into main triggers release-please and, when
   # release-please creates a new release, the publish job below.
   push:
@@ -53,8 +54,8 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      version: ${{ steps.release.outputs.version }}
+      release_created: ${{ steps.release.outputs['projects/ng-open-cv--release_created'] }}
+      version: ${{ steps.release.outputs['projects/ng-open-cv--version'] }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -70,8 +71,10 @@ jobs:
           manifest-file: .release-please-manifest.json
 
   publish-release:
-    if: needs.release-please-on-main.outputs.release_created == 'true'
-    needs: release-please-on-main
+    if: ${{ always() && needs.validate-pr-and-release.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.release-please-on-main.outputs.release_created == 'true') }}
+    needs:
+      - validate-pr-and-release
+      - release-please-on-main
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- use release-please path-scoped outputs for the ng-open-cv package
- add workflow_dispatch so the existing 1.1.0 GitHub release can be published after this fix lands
- allow publish-release to run after validation on manual dispatch or a release-created push

## Validation
- ruby YAML parse check for .github/workflows/publish-npm.yml

## Notes
- This does not publish immediately; after merge, run the Publish npm package workflow manually on main to publish the already-created 1.1.0 release.