### PR TITLE
ci: publish partial Angular package

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -101,7 +101,7 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Build package
-        run: npm run package
+        run: npm run build-lib && npm run copy-files
 
       - name: Publish to npm
         run: npm publish ./dist/ng-open-cv --provenance --access public

--- a/projects/ng-open-cv/tsconfig.lib.json
+++ b/projects/ng-open-cv/tsconfig.lib.json
@@ -17,5 +17,8 @@
   "exclude": [
     "src/test.ts",
     "**/*.spec.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
 }


### PR DESCRIPTION
## Summary
- compile the ng-open-cv library in Angular partial compilation mode for npm publishing
- avoid generating a nested package tarball before npm publish

## Validation
- npm run package
- npm publish ./dist/ng-open-cv --dry-run --access public

## Notes
- This fixes the publish failure from workflow run 26983585337 where npm blocked full compilation mode.