### PR TITLE
fix: resolve wasm binary path from script directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ Adjust the `scriptUrl` to contain the path to your opencvjs file. If you wanted 
 ```ts
 const openCVConfig: OpenCVOptions = {
   scriptUrl: `assets/opencv/wasm/3.4/opencv.js`,
-  wasmBinaryFile: 'wasm/3.4/opencv_js.wasm',
   usingWasm: true
 };
 ```
+
+The default loader expects `opencv_js.wasm` to live in the same folder as the configured WASM `opencv.js` file. If your app stores the binary somewhere else, pass a custom `locateFile` function in the configuration.
 
 ### Note: WASM is not supported on mobile Safari
 
@@ -100,11 +101,10 @@ import { AppComponent } from './app.component';
 import { NgOpenCVModule } from 'ng-open-cv';
 import { RouterModule } from '@angular/router';
 import { AppRoutingModule } from './app-routing.module';
-import { OpenCVOptions } from 'projects/ng-open-cv/src/public_api';
+import { OpenCVOptions } from 'ng-open-cv';
 
 const openCVConfig: OpenCVOptions = {
-  scriptUrl: `assets/opencv/opencv.js`,
-  wasmBinaryFile: 'wasm/opencv_js.wasm',
+  scriptUrl: `assets/opencv/wasm/3.4/opencv.js`,
   usingWasm: true
 };
 

--- a/projects/ng-open-cv/src/lib/ng-open-cv.models.ts
+++ b/projects/ng-open-cv/src/lib/ng-open-cv.models.ts
@@ -1,5 +1,5 @@
 export interface OpenCVLocateFileFn {
-  (path: string, scriptDirectory: string);
+  (path: string, scriptDirectory: string): string;
 }
 
 export interface OpenCvRuntimeInitializedFn {

--- a/projects/ng-open-cv/src/lib/ng-open-cv.service.spec.ts
+++ b/projects/ng-open-cv/src/lib/ng-open-cv.service.spec.ts
@@ -27,7 +27,6 @@ describe('NgOpenCVService', () => {
           useValue: {
             scriptUrl: 'assets/opencv/asm/3.4/opencv.js',
             usingWasm: false,
-            locateFile: () => 'assets/opencv/asm/3.4/opencv.js',
             onRuntimeInitialized: () => {}
           }
         }
@@ -56,5 +55,15 @@ describe('NgOpenCVService', () => {
     const service = TestBed.inject(NgOpenCVService);
     service.setScriptUrl('assets/custom/opencv.js');
     expect(service.OPENCV_URL).toBe('assets/custom/opencv.js');
+  });
+
+  it('should resolve the wasm binary from the script directory', () => {
+    TestBed.inject(NgOpenCVService);
+
+    const module = (globalThis as { Module?: { locateFile?: (path: string, scriptDirectory: string) => string } }).Module;
+
+    expect(module?.locateFile?.('opencv_js.wasm', 'http://localhost:4200/assets/opencv/wasm/3.4/')).toBe(
+      'http://localhost:4200/assets/opencv/wasm/3.4/opencv_js.wasm'
+    );
   });
 });

--- a/projects/ng-open-cv/src/lib/ng-open-cv.service.ts
+++ b/projects/ng-open-cv/src/lib/ng-open-cv.service.ts
@@ -63,9 +63,6 @@ export class NgOpenCVService {
   }
 
   private locateFile(path: string, scriptDirectory: string): string {
-    if (path === 'opencv_js.wasm') {
-      return `${scriptDirectory}/wasm/${path}`;
-    }
     return `${scriptDirectory}${path}`;
   }
 


### PR DESCRIPTION
## Summary
- fixes the default OpenCV.js WASM locator so it resolves opencv_js.wasm from the script directory instead of inserting an extra /wasm/ segment
- adds a unit test for the Angular dev-server path reported in #18
- updates README WASM examples to match the default loader behavior

## Validation
- npm run build-lib passed
- npm run ci and npm run test:lib:ci reached browser bundle generation but local ChromeHeadless could not start on this machine

Fixes #18