### PR TITLE
feat: expose OpenCV.js typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,22 @@ this.ngOpenCVService.createFileFromUrl(
 
 3. Typings
 
-To your `src/typings.d.ts` file. add 
+NgOpenCV exports OpenCV.js typings through the maintained `@opencvjs/types` package. To type the global `cv` object that OpenCV.js creates, add this to your `src/typings.d.ts` file:
 
+```ts
+import type { OpenCVModule } from 'ng-open-cv';
+
+declare global {
+  const cv: OpenCVModule;
+}
 ```
-declare var cv: any;
+
+You can also import OpenCV.js value types in application code:
+
+```ts
+import type { OpenCV } from 'ng-open-cv';
+
+let source: OpenCV.Mat;
 ```
 
 ## Demo

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@angular/cli": "^21.2.13",
         "@angular/compiler-cli": "^21.2.15",
         "@angular/language-service": "^21.2.15",
+        "@opencvjs/types": "^4.13.0-release.1",
         "@types/jasmine": "^6.0.0",
         "@types/node": "^25.9.1",
         "angular-cli-ghpages": "^3.0.0",
@@ -5168,6 +5169,13 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/@opencvjs/types": {
+      "version": "4.13.0-release.1",
+      "resolved": "https://registry.npmjs.org/@opencvjs/types/-/types-4.13.0-release.1.tgz",
+      "integrity": "sha512-HipuX/QrafzIjTPoTwnrgYkk3VUEpwLxmuekdwdnud0vvqyxUhMPmEX+a3dHglNkHhgkpKY22WFLHm0LItG6Mg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.113.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@angular/compiler-cli": "^21.2.15",
     "@angular/language-service": "^21.2.15",
     "@angular/build": "^21.2.13",
+    "@opencvjs/types": "^4.13.0-release.1",
     "@types/jasmine": "^6.0.0",
     "@types/node": "^25.9.1",
     "angular-cli-ghpages": "^3.0.0",

--- a/projects/ng-open-cv/ng-package.json
+++ b/projects/ng-open-cv/ng-package.json
@@ -1,6 +1,9 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/ng-open-cv",
+  "allowedNonPeerDependencies": [
+    "@opencvjs/types"
+  ],
   "lib": {
     "entryFile": "src/public_api.ts"
   }

--- a/projects/ng-open-cv/package.json
+++ b/projects/ng-open-cv/package.json
@@ -24,5 +24,8 @@
     "@angular/core": "^19.0.0 || ^20.0.0 || ^21.0.0",
     "rxjs": "^7.8.0",
     "zone.js": "^0.16.0"
+  },
+  "dependencies": {
+    "@opencvjs/types": "^4.13.0-release.1"
   }
 }

--- a/projects/ng-open-cv/src/lib/ng-open-cv.types.spec.ts
+++ b/projects/ng-open-cv/src/lib/ng-open-cv.types.spec.ts
@@ -1,0 +1,11 @@
+import type { OpenCV, OpenCVModule } from '../public_api';
+
+describe('OpenCV type exports', () => {
+  it('should expose OpenCV.js types for TypeScript consumers', () => {
+    const createMat = (cv: OpenCVModule): OpenCV.Mat => {
+      return cv.matFromArray(1, 1, cv.CV_8UC1, [0]);
+    };
+
+    expect(createMat).toEqual(jasmine.any(Function));
+  });
+});

--- a/projects/ng-open-cv/src/public_api.ts
+++ b/projects/ng-open-cv/src/public_api.ts
@@ -5,4 +5,5 @@
 export * from './lib/ng-open-cv.models';
 export * from './lib/ng-open-cv.service';
 export * from './lib/ng-open-cv.module';
-
+export type * as OpenCV from '@opencvjs/types/lib/opencv/_types';
+export type OpenCVModule = typeof import('@opencvjs/types/lib/opencv/_types');


### PR DESCRIPTION
## Summary
- expose OpenCV.js types from ng-open-cv as OpenCV and OpenCVModule
- add @opencvjs/types as the published package dependency so TypeScript consumers receive the declarations automatically
- add a compile-time spec that imports the public types and uses OpenCV.Mat/OpenCVModule
- replace the README cv: any guidance with typed examples

## Validation
- confirmed the type spec fails before the OpenCV export exists
- npm run test:lib:ci
- npm_config_cache=/tmp/npm-cache-ng-open-cv npm run package
- temporary strict TypeScript consumer compile against dist/ng-open-cv with no skipLibCheck
- npm run ci

Fixes #5